### PR TITLE
[nightshift] lint-fix: resolve all 15 clippy warnings

### DIFF
--- a/src/analysis/yara.rs
+++ b/src/analysis/yara.rs
@@ -81,21 +81,18 @@ pub fn scan_yara_rulepacks(
 
 fn derive_rule_severity(rule: &Rule<'_, '_>, pack: RulepackKind) -> &'static str {
     for (key, value) in rule.metadata() {
-        if key.eq_ignore_ascii_case("severity") {
-            if let MetaValue::String(severity) = value {
-                if let Some(canonical) = canonicalize_severity(severity) {
+        if key.eq_ignore_ascii_case("severity")
+            && let MetaValue::String(severity) = value
+                && let Some(canonical) = canonicalize_severity(severity) {
                     return canonical;
                 }
-            }
-        }
     }
 
     for (key, value) in rule.metadata() {
-        if key.eq_ignore_ascii_case("threat_level") {
-            if let MetaValue::Integer(level) = value {
+        if key.eq_ignore_ascii_case("threat_level")
+            && let MetaValue::Integer(level) = value {
                 return severity_from_threat_level(level);
             }
-        }
     }
 
     for tag in rule.tags() {

--- a/src/detectors/capability_base64_stager.rs
+++ b/src/detectors/capability_base64_stager.rs
@@ -185,7 +185,7 @@ pub fn detect(index: &EvidenceIndex) -> Vec<DetectorFinding> {
         return Vec::new();
     }
 
-    extracted_file_paths.extend(base64_samples.into_iter());
+    extracted_file_paths.extend(base64_samples);
 
     let rationale = format!(
         "Found long base64-like payload(s) with Base64 decode primitive(s) ({}) and dynamic code loading primitive(s) ({}). Network primitives observed: ({}).",

--- a/src/detectors/capability_network.rs
+++ b/src/detectors/capability_network.rs
@@ -71,9 +71,7 @@ pub fn detect(index: &EvidenceIndex) -> Vec<DetectorFinding> {
     }
 
     let urls_look_benign = urls_are_all_benign(&extracted_urls);
-    let severity = if extracted_urls.is_empty() {
-        "low"
-    } else if urls_look_benign {
+    let severity = if extracted_urls.is_empty() || urls_look_benign {
         "low"
     } else {
         "med"

--- a/src/detectors/mod.rs
+++ b/src/detectors/mod.rs
@@ -98,7 +98,7 @@ fn dedup_and_sort(values: &mut Vec<String>) {
 }
 
 fn dedup_locations(locations: &mut Vec<Location>) {
-    locations.sort_by(|left, right| location_key(left).cmp(&location_key(right)));
+    locations.sort_by_key(location_key);
     locations.dedup_by(|left, right| left == right);
 }
 

--- a/src/detectors/spec.rs
+++ b/src/detectors/spec.rs
@@ -119,7 +119,7 @@ mod tests {
 
     #[test]
     fn extract_urls_is_conservative_and_deduplicated() {
-        let strings = vec![
+        let strings = [
             "ping https://example.invalid/bootstrap",
             "fallback https://example.invalid/bootstrap and http://api.example.test/v1",
             "not-a-url: hxxps://example.invalid",

--- a/src/main.rs
+++ b/src/main.rs
@@ -306,9 +306,7 @@ fn load_ai_config() -> Option<AiConfig> {
         .filter(|value| !value.is_empty())
         .unwrap_or_else(|| "2024-10-21".to_string());
 
-    if deployment.is_none() {
-        return None;
-    }
+    deployment.as_ref()?;
 
     Some(AiConfig {
         endpoint,

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -225,10 +225,10 @@ fn jar_layer_depth(path: &str) -> usize {
     path.match_indices("!/").count()
 }
 
-fn find_shallowest_entry<'a, F>(
-    entries: &'a [ArchiveEntry],
+fn find_shallowest_entry<F>(
+    entries: &[ArchiveEntry],
     predicate: F,
-) -> Option<&'a ArchiveEntry>
+) -> Option<&ArchiveEntry>
 where
     F: Fn(&ArchiveEntry) -> bool,
 {
@@ -461,6 +461,24 @@ fn parse_mcmod_info(entries: &[ArchiveEntry]) -> Option<ModMetadata> {
     })
 }
 
+
+fn collect_fabric_entrypoints(value: &JsonValue, entrypoints: &mut Vec<String>) {
+    match value {
+        JsonValue::String(raw) => entrypoints.push(raw.clone()),
+        JsonValue::Array(items) => {
+            for item in items {
+                collect_fabric_entrypoints(item, entrypoints);
+            }
+        }
+        JsonValue::Object(object) => {
+            if let Some(inner) = object.get("value") {
+                collect_fabric_entrypoints(inner, entrypoints);
+            }
+        }
+        _ => {}
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::extract_mod_metadata;
@@ -514,19 +532,3 @@ mods = [
     }
 }
 
-fn collect_fabric_entrypoints(value: &JsonValue, entrypoints: &mut Vec<String>) {
-    match value {
-        JsonValue::String(raw) => entrypoints.push(raw.clone()),
-        JsonValue::Array(items) => {
-            for item in items {
-                collect_fabric_entrypoints(item, entrypoints);
-            }
-        }
-        JsonValue::Object(object) => {
-            if let Some(inner) = object.get("value") {
-                collect_fabric_entrypoints(inner, entrypoints);
-            }
-        }
-        _ => {}
-    }
-}

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -67,8 +67,8 @@ pub async fn run_scan(
         None
     };
 
-    if mb_mode == MalwareBazaarMatchMode::ShortCircuit {
-        if let Some(known_malware) = malwarebazaar_match.clone() {
+    if mb_mode == MalwareBazaarMatchMode::ShortCircuit
+        && let Some(known_malware) = malwarebazaar_match.clone() {
             let explanation = match known_malware.family.as_deref() {
                 Some(family) => format!("Known malware detected by hash match: {family}."),
                 None => "Known malware detected by hash match in MalwareBazaar.".to_string(),
@@ -102,7 +102,6 @@ pub async fn run_scan(
             persist_scan_result(state, &response).await?;
             return Ok(response);
         }
-    }
 
     let root_label = format!("{}.jar", request.upload_id);
     let entries = match analysis::read_archive_entries_recursive(root_label.as_str(), &bytes) {
@@ -299,8 +298,8 @@ pub async fn run_scan(
         ),
     };
 
-    if let Some(reason) = high_confidence_static_reason(&static_findings) {
-        if ai_verdict.result != "MALICIOUS" {
+    if let Some(reason) = high_confidence_static_reason(&static_findings)
+        && ai_verdict.result != "MALICIOUS" {
             ai_verdict.result = "MALICIOUS".to_string();
             ai_verdict.confidence = ai_verdict.confidence.max(0.9);
             ai_verdict.risk_score = ai_verdict.risk_score.max(90);
@@ -310,7 +309,6 @@ pub async fn run_scan(
             );
             method = format!("static_override({method})");
         }
-    }
 
     let response = ScanRunResponse {
         scan_id: build_scan_id(scan_id_override)?,
@@ -414,6 +412,17 @@ fn build_scan_id(scan_id_override: Option<&str>) -> Result<String> {
     }
 
     Ok(Uuid::new_v4().simple().to_string())
+}
+
+
+async fn persist_scan_result(state: &AppState, payload: &ScanRunResponse) -> Result<()> {
+    let path = state.scans_dir.join(format!("{}.json", payload.scan_id));
+    let payload_bytes =
+        serde_json::to_vec_pretty(payload).context("Failed to serialize scan result")?;
+    fs::write(&path, payload_bytes)
+        .await
+        .with_context(|| format!("Failed to persist scan result: {}", path.display()))?;
+    Ok(())
 }
 
 #[cfg(test)]
@@ -534,12 +543,3 @@ mod tests {
     }
 }
 
-async fn persist_scan_result(state: &AppState, payload: &ScanRunResponse) -> Result<()> {
-    let path = state.scans_dir.join(format!("{}.json", payload.scan_id));
-    let payload_bytes =
-        serde_json::to_vec_pretty(payload).context("Failed to serialize scan result")?;
-    fs::write(&path, payload_bytes)
-        .await
-        .with_context(|| format!("Failed to persist scan result: {}", path.display()))?;
-    Ok(())
-}

--- a/src/verdict.rs
+++ b/src/verdict.rs
@@ -197,11 +197,10 @@ fn collect_extracted_artifacts(static_findings: &StaticFindings) -> ExtractedArt
         if let Some(items) = indicator.extracted_urls.as_ref() {
             for raw in items {
                 urls.insert(truncate_string(raw.as_str(), 220));
-                if let Ok(parsed) = Url::parse(raw.as_str()) {
-                    if let Some(host) = parsed.host_str() {
+                if let Ok(parsed) = Url::parse(raw.as_str())
+                    && let Some(host) = parsed.host_str() {
                         domains.insert(host.trim().to_ascii_lowercase());
                     }
-                }
             }
         }
 
@@ -655,101 +654,6 @@ pub fn heuristic_verdict(
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use std::collections::{BTreeMap, HashMap};
-
-    use super::heuristic_verdict;
-    use crate::profile::{CapabilityProfile, ModMetadata};
-    use crate::{Indicator, StaticFindings};
-
-    fn empty_profile() -> CapabilityProfile {
-        CapabilityProfile {
-            mod_metadata: ModMetadata::default(),
-            capabilities: BTreeMap::new(),
-            yara_hits: Vec::new(),
-            low_signal_indicators: Vec::new(),
-            reconstructed_strings: Vec::new(),
-            suspicious_manifest_entries: Vec::new(),
-            class_count: 0,
-            jar_size_bytes: 0,
-        }
-    }
-
-    fn findings_with(indicator: Indicator) -> StaticFindings {
-        StaticFindings {
-            matches: vec![indicator],
-            counts_by_category: HashMap::new(),
-            counts_by_severity: HashMap::new(),
-            matched_pattern_ids: Vec::new(),
-            matched_signature_ids: Vec::new(),
-            analyzed_files: 1,
-        }
-    }
-
-    #[test]
-    fn network_primitive_medium_is_not_enough_to_be_suspicious() {
-        let findings = findings_with(Indicator {
-            source: "detector".to_string(),
-            id: "DETC-02.NETWORK_PRIMITIVE".to_string(),
-            title: "Outbound networking primitive detected".to_string(),
-            category: "capability".to_string(),
-            severity: "med".to_string(),
-            file_path: Some("Example.class".to_string()),
-            evidence: "java/net/URL.openConnection".to_string(),
-            rationale: "broad".to_string(),
-            evidence_locations: None,
-            extracted_urls: Some(vec!["https://example.invalid".to_string()]),
-            extracted_commands: None,
-            extracted_file_paths: None,
-        });
-
-        let verdict = heuristic_verdict(&findings, &empty_profile(), "no-ai");
-        assert_eq!(verdict.result, "CLEAN");
-    }
-
-    #[test]
-    fn pattern_only_medium_is_not_enough_to_be_suspicious() {
-        let findings = findings_with(Indicator {
-            source: "pattern".to_string(),
-            id: "OBF-BASE64".to_string(),
-            title: "Long base64 blob".to_string(),
-            category: "obfuscation".to_string(),
-            severity: "med".to_string(),
-            file_path: Some("Example.class".to_string()),
-            evidence: "AAAA...".to_string(),
-            rationale: "Broad indicator".to_string(),
-            evidence_locations: None,
-            extracted_urls: None,
-            extracted_commands: None,
-            extracted_file_paths: None,
-        });
-
-        let verdict = heuristic_verdict(&findings, &empty_profile(), "no-ai");
-        assert_eq!(verdict.result, "CLEAN");
-    }
-
-    #[test]
-    fn high_signal_pattern_still_makes_it_suspicious() {
-        let findings = findings_with(Indicator {
-            source: "pattern".to_string(),
-            id: "NET-DISCORD-WEBHOOK".to_string(),
-            title: "Discord webhook endpoint".to_string(),
-            category: "network".to_string(),
-            severity: "high".to_string(),
-            file_path: Some("Example.class".to_string()),
-            evidence: "https://discord.com/api/webhooks/123/abc".to_string(),
-            rationale: "High signal".to_string(),
-            evidence_locations: None,
-            extracted_urls: None,
-            extracted_commands: None,
-            extracted_file_paths: None,
-        });
-
-        let verdict = heuristic_verdict(&findings, &empty_profile(), "no-ai");
-        assert_eq!(verdict.result, "SUSPICIOUS");
-    }
-}
 
 fn build_request(
     config: &AiConfig,
@@ -868,11 +772,10 @@ fn parse_verdict_content(content: &str) -> Result<AiVerdictResponse> {
     }
 
     let trimmed = content.trim();
-    if let Some(stripped) = trim_code_fence(trimmed) {
-        if let Some(parsed) = decode_verdict_json(stripped) {
+    if let Some(stripped) = trim_code_fence(trimmed)
+        && let Some(parsed) = decode_verdict_json(stripped) {
             return Ok(parsed);
         }
-    }
 
     if let Some((start, end)) = json_object_span(trimmed) {
         let candidate = &trimmed[start..=end];
@@ -1058,3 +961,100 @@ fn indicator_weight(indicator: &crate::Indicator, severity: &str) -> u32 {
 
     severity_weight(severity)
 }
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{BTreeMap, HashMap};
+
+    use super::heuristic_verdict;
+    use crate::profile::{CapabilityProfile, ModMetadata};
+    use crate::{Indicator, StaticFindings};
+
+    fn empty_profile() -> CapabilityProfile {
+        CapabilityProfile {
+            mod_metadata: ModMetadata::default(),
+            capabilities: BTreeMap::new(),
+            yara_hits: Vec::new(),
+            low_signal_indicators: Vec::new(),
+            reconstructed_strings: Vec::new(),
+            suspicious_manifest_entries: Vec::new(),
+            class_count: 0,
+            jar_size_bytes: 0,
+        }
+    }
+
+    fn findings_with(indicator: Indicator) -> StaticFindings {
+        StaticFindings {
+            matches: vec![indicator],
+            counts_by_category: HashMap::new(),
+            counts_by_severity: HashMap::new(),
+            matched_pattern_ids: Vec::new(),
+            matched_signature_ids: Vec::new(),
+            analyzed_files: 1,
+        }
+    }
+
+    #[test]
+    fn network_primitive_medium_is_not_enough_to_be_suspicious() {
+        let findings = findings_with(Indicator {
+            source: "detector".to_string(),
+            id: "DETC-02.NETWORK_PRIMITIVE".to_string(),
+            title: "Outbound networking primitive detected".to_string(),
+            category: "capability".to_string(),
+            severity: "med".to_string(),
+            file_path: Some("Example.class".to_string()),
+            evidence: "java/net/URL.openConnection".to_string(),
+            rationale: "broad".to_string(),
+            evidence_locations: None,
+            extracted_urls: Some(vec!["https://example.invalid".to_string()]),
+            extracted_commands: None,
+            extracted_file_paths: None,
+        });
+
+        let verdict = heuristic_verdict(&findings, &empty_profile(), "no-ai");
+        assert_eq!(verdict.result, "CLEAN");
+    }
+
+    #[test]
+    fn pattern_only_medium_is_not_enough_to_be_suspicious() {
+        let findings = findings_with(Indicator {
+            source: "pattern".to_string(),
+            id: "OBF-BASE64".to_string(),
+            title: "Long base64 blob".to_string(),
+            category: "obfuscation".to_string(),
+            severity: "med".to_string(),
+            file_path: Some("Example.class".to_string()),
+            evidence: "AAAA...".to_string(),
+            rationale: "Broad indicator".to_string(),
+            evidence_locations: None,
+            extracted_urls: None,
+            extracted_commands: None,
+            extracted_file_paths: None,
+        });
+
+        let verdict = heuristic_verdict(&findings, &empty_profile(), "no-ai");
+        assert_eq!(verdict.result, "CLEAN");
+    }
+
+    #[test]
+    fn high_signal_pattern_still_makes_it_suspicious() {
+        let findings = findings_with(Indicator {
+            source: "pattern".to_string(),
+            id: "NET-DISCORD-WEBHOOK".to_string(),
+            title: "Discord webhook endpoint".to_string(),
+            category: "network".to_string(),
+            severity: "high".to_string(),
+            file_path: Some("Example.class".to_string()),
+            evidence: "https://discord.com/api/webhooks/123/abc".to_string(),
+            rationale: "High signal".to_string(),
+            evidence_locations: None,
+            extracted_urls: None,
+            extracted_commands: None,
+            extracted_file_paths: None,
+        });
+
+        let verdict = heuristic_verdict(&findings, &empty_profile(), "no-ai");
+        assert_eq!(verdict.result, "SUSPICIOUS");
+    }
+}
+


### PR DESCRIPTION
Automated by Nightshift v3 (GLM 5.1).

**Task:** lint-fix
**Category:** pr
**Changes:** Resolved all 15 clippy warnings across 9 files.

### Fixes applied
- **Collapsible if** (4): Merged nested if conditions in `yara.rs`, `scan.rs`, `verdict.rs`
- **Needless lifetimes** (1): Removed explicit `'a` lifetime in `profile.rs`
- **Question mark** (1): Replaced `if-None-return` with `?` operator in `main.rs`
- **Redundant closure** (1): Replaced `|x| f(x)` with `f` in `detectors/mod.rs`
- **Useless conversion** (1): Removed `.into_iter()` in `capability_base64_stager.rs`
- **If same then else** (1): Collapsed identical branches in `capability_network.rs`
- **Useless vec** (1): Replaced `vec![]` with array literal in `spec.rs` test
- **Items after test module** (3): Moved helper functions before `#[cfg(test)]` in `profile.rs`, `scan.rs`, `verdict.rs`

### Result
- **Before:** 15 clippy warnings
- **After:** 0 clippy warnings
- Build: ✅ passes
- Tests: ✅ pass (1 pre-existing fixture failure unrelated to changes)

Merge if useful, close if not.