### PR TITLE
perf: fix redundant regex compilations, YARA scanner churn, and buffer clones

### DIFF
--- a/src/analysis/archive.rs
+++ b/src/analysis/archive.rs
@@ -47,7 +47,7 @@ fn walk_archive(
     budgets: &mut ArchiveBudgets,
     entries: &mut Vec<ArchiveEntry>,
 ) -> Result<()> {
-    let cursor = Cursor::new(jar_bytes.to_vec());
+    let cursor = Cursor::new(jar_bytes);
     let mut archive = ZipArchive::new(cursor)?;
 
     for index in 0..archive.len() {

--- a/src/analysis/yara.rs
+++ b/src/analysis/yara.rs
@@ -67,8 +67,8 @@ pub fn scan_yara_rulepacks(
     let mut findings = Vec::new();
 
     for pack in packs {
+        let mut scanner = Scanner::new(&pack.rules);
         for entry in entries {
-            let mut scanner = Scanner::new(&pack.rules);
             let scan_results = scanner.scan(entry.bytes.as_slice())?;
             for rule in scan_results.matching_rules() {
                 findings.push((

--- a/src/detectors/spec.rs
+++ b/src/detectors/spec.rs
@@ -1,5 +1,11 @@
 use regex::Regex;
 use std::collections::BTreeSet;
+use std::sync::LazyLock;
+
+static URL_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"(?i)https?://[a-z0-9][a-z0-9._:%+\-]*(?:\.[a-z0-9][a-z0-9._:%+\-]*)+(?:/[^\s\"'<>]*)?"#)
+        .expect("url regex must compile")
+});
 
 /// Shell command tokens used to identify command-like strings
 pub const COMMAND_TOKENS: &[&str] = &["powershell", "cmd.exe", "/bin/sh", "curl", "wget"];
@@ -75,14 +81,9 @@ pub const NETWORK_PRIMITIVE_MATCHERS: &[(&str, &str, &str)] = &[
 
 /// Extract HTTP/HTTPS URLs from an iterator of strings using regex matching
 pub fn extract_urls<'a>(strings: impl Iterator<Item = &'a str>) -> Vec<String> {
-    let regex = Regex::new(
-        r#"(?i)https?://[a-z0-9][a-z0-9._:%+\-]*(?:\.[a-z0-9][a-z0-9._:%+\-]*)+(?:/[^\s\"'<>]*)?"#,
-    )
-    .expect("url regex must compile");
-
     let mut urls = Vec::new();
     for value in strings {
-        for found in regex.find_iter(value) {
+        for found in URL_REGEX.find_iter(value) {
             urls.push(found.as_str().to_string());
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -233,6 +233,17 @@ pub fn run_static_analysis(
         ),
     ];
 
+    let compiled_sig_regexes: Vec<Option<Regex>> = signatures
+        .iter()
+        .map(|sig| {
+            if sig.kind == "regex" {
+                Regex::new(&sig.value).ok()
+            } else {
+                None
+            }
+        })
+        .collect();
+
     for entry in entries {
         let entry_text = entry.text.as_deref().unwrap_or("");
 
@@ -264,13 +275,13 @@ pub fn run_static_analysis(
             }
         }
 
-        for signature in signatures {
+        for (i, signature) in signatures.iter().enumerate() {
             let hit = match signature.kind.as_str() {
                 "token" => entry_text
                     .find(&signature.value)
                     .map(|offset| (offset, offset + signature.value.len())),
-                "regex" => Regex::new(&signature.value)
-                    .ok()
+                "regex" => compiled_sig_regexes[i]
+                    .as_ref()
                     .and_then(|re| re.find(entry_text).map(|m| (m.start(), m.end()))),
                 _ => None,
             };


### PR DESCRIPTION
Fixes several O(N) performance bottlenecks during static analysis and archive extraction.

#### Changes
* **`src/detectors/spec.rs`**: Cache `URL_REGEX` with `LazyLock` instead of recompiling on every `extract_urls` invocation.
* **`src/lib.rs`**: Pre-compile regex signatures before the archive entry loop in `run_static_analysis`.
* **`src/analysis/yara.rs`**: Reuse the `yara_x::Scanner` instance across entries per rulepack instead of instantiating it per file.
* **`src/analysis/archive.rs`**: Pass `jar_bytes` directly to `Cursor::new` in `walk_archive` to avoid cloning the full JAR buffer with `.to_vec()`.

Eliminates unnecessary CPU overhead and memory allocations on large JAR scans. No API or logic changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR removes redundant allocations and repeated initialization from static-analysis hot paths.
- Reuses one YARA scanner per rulepack while preserving per-entry scan results.
- Compiles signature and URL regular expressions once instead of once per entry or invocation.
- Reads archives through a borrowed byte-slice cursor instead of cloning the complete archive buffer.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the reviewed optimizations preserving existing matching and archive-processing behavior.

Scanner reuse follows the YARA API's repeated-scan semantics, borrowed archive data remains valid throughout traversal, and both regex caches preserve the original expressions and signature ordering.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/analysis/archive.rs | Replaces an owned buffer clone with a borrowed cursor whose lifetime covers archive traversal, including recursive nested-archive processing. |
| src/analysis/yara.rs | Reuses the YARA scanner as supported by its repeated-scan contract, with match state reset between scans. |
| src/detectors/spec.rs | Moves the unchanged URL expression into a thread-safe static LazyLock compatible with the repository's Rust edition. |
| src/lib.rs | Precompiles regex signatures in a vector aligned with the unchanged signature ordering and reuses them for every entry. |

<sub>Reviews (1): Last reviewed commit: ["refactor: simplify cursor initialization..."](https://github.com/microck/jarspect/commit/2efa02c9230e8beb040ba0adf6c54b1c1f012ba3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48895602)</sub>

<!-- /greptile_comment -->